### PR TITLE
Attempt to supply "-Dmy.prop=hello" not working

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
               <buildArgs>
                 <buildArg>--no-fallback</buildArg>
                 <buildArg>--no-server</buildArg>
+                <buildArg>-Dmy.prop=hello</buildArg>
               </buildArgs>
             </configuration>
           </plugin>


### PR DESCRIPTION
This attempt doesn't work because

> If you compile that with, e.g., native-image -Dfoo=bar App the system property foo will be available at image build time.

https://www.graalvm.org/22.0/reference-manual/native-image/Properties/

